### PR TITLE
Remove default value for project-setup-dialog-text

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,8 +30,7 @@
 			"key": "project-setup-dialog-text",
 			"name": "Project Setup page dialog box text",
 			"required": true,
-			"type": "text",
-			"default": "REDCap's built-in record auto-numbering is being overridden by the \"Custom Record Auto-numbering\" External Module."
+			"type": "text"
 		}
 	],
 


### PR DESCRIPTION
The default value prevented module enabling on new systems
Fixes Issue #1