### PR TITLE
Add check that the module is enabled before acting in __construct

### DIFF
--- a/RecordAutonumber.php
+++ b/RecordAutonumber.php
@@ -55,6 +55,8 @@ class RecordAutonumber extends AbstractExternalModule
                 $this->autonumberGenerator = null;
                 
                 if ($this->project_id > 0) {
+                        // Do not attempt any configuration unless the module is enabled
+                        if (!$this->getProjectSettings()['enabled']['value']) return;
                         try {
                                 // read all the config options
                                 $settingsArray = $this->getProjectSettings($this->project_id);


### PR DESCRIPTION
Closes #5 

Given that `__construct()` seems to run on _every page_ with no regard for the module's activation status at the project level, this modules construct block should probably be moved to a `redcap_module_project_enable` hook.

A bit more digging shows that unaffected versions of redcap keep `PROJECT_ID` as 0 if the module is inactive.

Outside the scope of this specific PR, now that the EM repo is private (RIP) I had to hunt for complete hook documentation (the Documentation link in the ControlCenter is quite lacking); best bet is to go to `redcap_vx.y.z/ExternalModules/docs/official-documentation.md` in your filesystem.