### PR TITLE
Fix crash of module when using "padded integer increment with prefix"

### DIFF
--- a/AutonumberGenerators/PrefixAndPad.php
+++ b/AutonumberGenerators/PrefixAndPad.php
@@ -91,4 +91,8 @@ class PrefixAndPad extends AbstractAutonumberGenerator {
         public function requireDAG() {
                 return false;
         }
+
+        public function getRequiredDataEntryFields() {
+                return array();
+        }
 }


### PR DESCRIPTION
>we [...] get this error as we attempted to configure it on a module at the project level. It happened after selecting the second option and choosing save.

>REDCap crashed due to an unexpected PHP fatal error!

>Error message: Class MCRI\RecordAutonumber\PrefixAndPad contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (MCRI\RecordAutonumber\AbstractAutonumberGenerator::getRequiredDataEntryFields)
File: /var/www.backup/redcap-20201208T2046/modules/record_autonumbering_v0.0.0/AutonumberGenerators/PrefixAndPad.php
Line: 0

>The project wherein I configured the PrefixAndPad now crashes whenever the module is enabled and we access the External Modules page or record_status_dashboard

>We also saw other events wherein the module was disabled at the system level, yet we got no error message. One happened when I saved the configuration using the Unix timestamp option. Weird stuff.