### PR TITLE
Prefixed the allRecords temp variable with $.

### DIFF
--- a/AutonumberGenerators/IncrementFromSeed.php
+++ b/AutonumberGenerators/IncrementFromSeed.php
@@ -34,7 +34,7 @@ class IncrementFromSeed extends AbstractAutonumberGenerator {
                 
                 $allRecords = REDCap::getData('array',null,REDCap::getRecordIdField());
 
-                if (count(allRecords) === 0) { return $seed; }
+                if (count($allRecords) === 0) { return $seed; }
 
                 // find the current max integer id
                 $currentMax = 0;


### PR DESCRIPTION
Module was throwing: "Error: Undefined constant "MCRI\RecordAutonumber\allRecords" in AutonumberGenerators\IncrementFromSeed.php:37

This fixes that. 