### PR TITLE
Add a random 6-character alphanumeric ID option

### DIFF
--- a/AutonumberGenerators/RandomAlphanumeric.php
+++ b/AutonumberGenerators/RandomAlphanumeric.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * REDCap External Module: Record Autonumber
+ * @author Luke Stevens, Murdoch Children's Research Institute
+ * @author Eric Weber, UF PAIN Lab
+ */
+namespace MCRI\RecordAutonumber;
+
+/**
+ * RandomAlphanumeric
+ * Create record id as a 6-character randomized alphanumeric string
+ * @author Eric Weber, UF PAIN Lab
+ */
+class RandomAlphanumeric extends AbstractAutonumberGenerator {
+        const PATTERN = '/^[A-Z0-9]{6}$/';
+        const CHARSET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Excludes I, O, 0, 1 to avoid confusion
+        const LENGTH = 6;
+
+        protected function validateConfiguration() {
+                // no settings required for RandomAlphanumeric
+        }
+
+        public function getNextRecordId($params=null) {
+                $charset = self::CHARSET;
+                $charsetLength = strlen($charset);
+                $id = '';
+
+                for ($i = 0; $i < self::LENGTH; $i++) {
+                        $randomIndex = random_int(0, $charsetLength - 1);
+                        $id .= $charset[$randomIndex];
+                }
+
+                return $id;
+        }
+
+        public function idMatchesExpectedPattern($id) {
+                return preg_match(self::PATTERN, $id);
+        }
+
+        public function requireDAG() {
+                return false;
+        }
+
+        public function getRequiredDataEntryFields() {
+                return array();
+        }
+}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ This module introduces a range of additional options, such as having the first r
 1. **Unix timestamp (16 digits)**: This option will create a record ID based upon a Unix timestamp. A Unix timestamp is the number of seconds since January 1st, 1970 (UTC).
   - See: <https://www.unixtimestamp.com/> for more information about Unix timestamps.
 
+1. **Random 6-character alphanumeric ID**: This option generates a random 6-character alphanumeric string for each new record ID. The character set excludes ambiguous characters (I, O, 0, 1) to improve readability.
+  - Example IDs: `A7K2M9`, `X3PB5N`, `H8QR4T`
+  - This is useful when you need non-sequential, non-guessable record IDs for privacy or blinding purposes.
+  - _Note_: While collisions are statistically unlikely (over 700 million possible combinations), the module will generate a new ID if a collision is detected.
+
 1. **A project-specific custom auto-numbering schema**: The module design supports the addition of novel auto-numbering schemes via custom code. This is an advanced feature for module developers.
 
 For a more detailed explanation, see the [Custom Record Auto-numbering User Guide](https://www.ctsi.ufl.edu/wordpress/files/2021/04/Custom-Record-Auto-numbering-External-Module-User-Guide.pdf) created by Taryn Stoffs.

--- a/config.json
+++ b/config.json
@@ -42,6 +42,7 @@
 				{ "value": "DAGIncrement", "name": "Increment within DAG using part of DAG name" },
 				{ "value": "DateTimeFormat", "name": "Date/time in selected format" },
 				{ "value": "Timestamp", "name": "Unix timestamp (16 digits)" },
+				{ "value": "RandomAlphanumeric", "name": "Random 6-character alphanumeric ID" },
 				{ "value": "Custom", "name": "A project-specific custom auto-numbering schema" }
 			]
 		},


### PR DESCRIPTION
@lsgs, this is a locally-authored extension to your module written by one of my customers, @ebweberUF. It 
adds a random 6-character alphanumeric ID option for generating non-sequential, non-guessable record IDs. I tested it here under RC 15.9.1, and it works fine. 

Please let Eric and me know if you see any issues. I'm not sure who will make the changes, but we'll get it done.
